### PR TITLE
Release 8.0.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# :pencil: Description
+- FIXME
+
+# :bulb: What’s new?
+- FIXME
+
+# :no_mouth: What’s missing?
+- FIXME
+
+# :books: References
+- FIXME

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .build
 Build/
 GoogleFrameworks/
+xcuserdata/

--- a/GoogleMaps-sim.xcodeproj/project.pbxproj
+++ b/GoogleMaps-sim.xcodeproj/project.pbxproj
@@ -7,6 +7,58 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		45F6B4C72A44E43E0090EEC1 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4932A44E43D0090EEC1 /* GMSOverlayLayer.h */; };
+		45F6B4C82A44E43E0090EEC1 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4942A44E43D0090EEC1 /* GMSMarkerLayer.h */; };
+		45F6B4C92A44E43E0090EEC1 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4952A44E43D0090EEC1 /* GMSPanoramaLink.h */; };
+		45F6B4CA2A44E43E0090EEC1 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4962A44E43D0090EEC1 /* GMSPanoramaCamera.h */; };
+		45F6B4CB2A44E43E0090EEC1 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4972A44E43D0090EEC1 /* GMSPanoramaSource.h */; };
+		45F6B4CC2A44E43E0090EEC1 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4982A44E43D0090EEC1 /* GMSMapView.h */; };
+		45F6B4CD2A44E43E0090EEC1 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4992A44E43D0090EEC1 /* GMSPolyline.h */; };
+		45F6B4CE2A44E43E0090EEC1 /* GMSAdvancedMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B49A2A44E43D0090EEC1 /* GMSAdvancedMarker.h */; };
+		45F6B4CF2A44E43E0090EEC1 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B49B2A44E43D0090EEC1 /* GMSProjection.h */; };
+		45F6B4D02A44E43E0090EEC1 /* GMSPinImageOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B49C2A44E43D0090EEC1 /* GMSPinImageOptions.h */; };
+		45F6B4D12A44E43E0090EEC1 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B49D2A44E43D0090EEC1 /* GMSMutablePath.h */; };
+		45F6B4D22A44E43E0090EEC1 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B49E2A44E43D0090EEC1 /* GMSCALayer.h */; };
+		45F6B4D32A44E43E0090EEC1 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B49F2A44E43D0090EEC1 /* GMSPolygon.h */; };
+		45F6B4D42A44E43E0090EEC1 /* GMSPinImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A02A44E43D0090EEC1 /* GMSPinImage.h */; };
+		45F6B4D52A44E43E0090EEC1 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A12A44E43D0090EEC1 /* GMSIndoorDisplay.h */; };
+		45F6B4D62A44E43E0090EEC1 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A22A44E43D0090EEC1 /* GMSSyncTileLayer.h */; };
+		45F6B4D72A44E43E0090EEC1 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A32A44E43D0090EEC1 /* GMSStrokeStyle.h */; };
+		45F6B4D82A44E43E0090EEC1 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A42A44E43D0090EEC1 /* GMSIndoorBuilding.h */; };
+		45F6B4D92A44E43E0090EEC1 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A52A44E43D0090EEC1 /* GMSPanoramaView.h */; };
+		45F6B4DA2A44E43E0090EEC1 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A62A44E43D0090EEC1 /* GMSServices.h */; };
+		45F6B4DB2A44E43E0090EEC1 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A72A44E43D0090EEC1 /* GMSCameraUpdate.h */; };
+		45F6B4DC2A44E43E0090EEC1 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A82A44E43D0090EEC1 /* GMSMapView+Animation.h */; };
+		45F6B4DD2A44E43E0090EEC1 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4A92A44E43D0090EEC1 /* GMSPanoramaService.h */; };
+		45F6B4DE2A44E43E0090EEC1 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4AA2A44E43D0090EEC1 /* GMSCircle.h */; };
+		45F6B4DF2A44E43E0090EEC1 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4AB2A44E43D0090EEC1 /* GMSPolygonLayer.h */; };
+		45F6B4E02A44E43E0090EEC1 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4AC2A44E43D0090EEC1 /* GMSIndoorLevel.h */; };
+		45F6B4E12A44E43E0090EEC1 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4AD2A44E43D0090EEC1 /* GMSCoordinateBounds+GoogleMaps.h */; };
+		45F6B4E22A44E43E0090EEC1 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4AE2A44E43D0090EEC1 /* GMSStyleSpan.h */; };
+		45F6B4E32A44E43E0090EEC1 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4AF2A44E43D0090EEC1 /* GMSURLTileLayer.h */; };
+		45F6B4E42A44E43E0090EEC1 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B02A44E43D0090EEC1 /* GMSPanoramaCameraUpdate.h */; };
+		45F6B4E52A44E43E0090EEC1 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B12A44E43D0090EEC1 /* GMSCameraPosition.h */; };
+		45F6B4E62A44E43E0090EEC1 /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B22A44E43D0090EEC1 /* GMSMarkerAnimation.h */; };
+		45F6B4E72A44E43E0090EEC1 /* GMSMapID.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B32A44E43D0090EEC1 /* GMSMapID.h */; };
+		45F6B4E82A44E43E0090EEC1 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B42A44E43E0090EEC1 /* GMSMarker.h */; };
+		45F6B4E92A44E43E0090EEC1 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B52A44E43E0090EEC1 /* GMSPanoramaLayer.h */; };
+		45F6B4EA2A44E43E0090EEC1 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B62A44E43E0090EEC1 /* GMSGeocoder.h */; };
+		45F6B4EB2A44E43E0090EEC1 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B72A44E43E0090EEC1 /* GMSMapLayer.h */; };
+		45F6B4EC2A44E43E0090EEC1 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B82A44E43E0090EEC1 /* GMSTileLayer.h */; };
+		45F6B4ED2A44E43E0090EEC1 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4B92A44E43E0090EEC1 /* GMSPanorama.h */; };
+		45F6B4EE2A44E43E0090EEC1 /* GMSPinImageGlyph.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4BA2A44E43E0090EEC1 /* GMSPinImageGlyph.h */; };
+		45F6B4EF2A44E43E0090EEC1 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4BB2A44E43E0090EEC1 /* GMSOverlay.h */; };
+		45F6B4F02A44E43E0090EEC1 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4BC2A44E43E0090EEC1 /* GMSAccessibilityLabels.h */; };
+		45F6B4F12A44E43E0090EEC1 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4BD2A44E43E0090EEC1 /* GMSOrientation.h */; };
+		45F6B4F22A44E43E0090EEC1 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4BE2A44E43E0090EEC1 /* GMSGroundOverlay.h */; };
+		45F6B4F32A44E43E0090EEC1 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4BF2A44E43E0090EEC1 /* GMSMapStyle.h */; };
+		45F6B4F42A44E43E0090EEC1 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C02A44E43E0090EEC1 /* GMSAddress.h */; };
+		45F6B4F52A44E43E0090EEC1 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C12A44E43E0090EEC1 /* GMSGeometryUtils.h */; };
+		45F6B4F62A44E43E0090EEC1 /* GMSCollisionBehavior.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C22A44E43E0090EEC1 /* GMSCollisionBehavior.h */; };
+		45F6B4F72A44E43E0090EEC1 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C32A44E43E0090EEC1 /* GMSStampStyle.h */; };
+		45F6B4F82A44E43E0090EEC1 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C42A44E43E0090EEC1 /* GMSPath.h */; };
+		45F6B4F92A44E43E0090EEC1 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C52A44E43E0090EEC1 /* GoogleMaps.h */; };
+		45F6B4FA2A44E43E0090EEC1 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4C62A44E43E0090EEC1 /* GMSUISettings.h */; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
@@ -54,54 +106,8 @@
 		8A6642052539847A000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
 		8A66421625398491000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
 		8A66421725398499000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
-		8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
 		8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
-		8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E026526A8E00C2AD24 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E526526A8E00C2AD24 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081726526A9000C2AD24 /* GMSMapID.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E626526A8E00C2AD24 /* GMSMapID.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E826526A8F00C2AD24 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EC26526A8F00C2AD24 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082126526A9000C2AD24 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F026526A8F00C2AD24 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F326526A8F00C2AD24 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F626526A8F00C2AD24 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FA26526A8F00C2AD24 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080026526A8F00C2AD24 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080426526A8F00C2AD24 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080926526A9000C2AD24 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080B26526A9000C2AD24 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080D26526A9000C2AD24 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71083F26526AE800C2AD24 /* GooglePlaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -127,7 +133,6 @@
 		8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8B4E8E278317090014EB33 /* Metal.framework */; };
-		8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +153,58 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		45F6B4932A44E43D0090EEC1 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
+		45F6B4942A44E43D0090EEC1 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
+		45F6B4952A44E43D0090EEC1 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
+		45F6B4962A44E43D0090EEC1 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
+		45F6B4972A44E43D0090EEC1 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
+		45F6B4982A44E43D0090EEC1 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
+		45F6B4992A44E43D0090EEC1 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
+		45F6B49A2A44E43D0090EEC1 /* GMSAdvancedMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAdvancedMarker.h; sourceTree = "<group>"; };
+		45F6B49B2A44E43D0090EEC1 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
+		45F6B49C2A44E43D0090EEC1 /* GMSPinImageOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPinImageOptions.h; sourceTree = "<group>"; };
+		45F6B49D2A44E43D0090EEC1 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
+		45F6B49E2A44E43D0090EEC1 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
+		45F6B49F2A44E43D0090EEC1 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
+		45F6B4A02A44E43D0090EEC1 /* GMSPinImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPinImage.h; sourceTree = "<group>"; };
+		45F6B4A12A44E43D0090EEC1 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
+		45F6B4A22A44E43D0090EEC1 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
+		45F6B4A32A44E43D0090EEC1 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
+		45F6B4A42A44E43D0090EEC1 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
+		45F6B4A52A44E43D0090EEC1 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
+		45F6B4A62A44E43D0090EEC1 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
+		45F6B4A72A44E43D0090EEC1 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
+		45F6B4A82A44E43D0090EEC1 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
+		45F6B4A92A44E43D0090EEC1 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
+		45F6B4AA2A44E43D0090EEC1 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
+		45F6B4AB2A44E43D0090EEC1 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
+		45F6B4AC2A44E43D0090EEC1 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
+		45F6B4AD2A44E43D0090EEC1 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
+		45F6B4AE2A44E43D0090EEC1 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
+		45F6B4AF2A44E43D0090EEC1 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
+		45F6B4B02A44E43D0090EEC1 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
+		45F6B4B12A44E43D0090EEC1 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
+		45F6B4B22A44E43D0090EEC1 /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
+		45F6B4B32A44E43D0090EEC1 /* GMSMapID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapID.h; sourceTree = "<group>"; };
+		45F6B4B42A44E43E0090EEC1 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
+		45F6B4B52A44E43E0090EEC1 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
+		45F6B4B62A44E43E0090EEC1 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
+		45F6B4B72A44E43E0090EEC1 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
+		45F6B4B82A44E43E0090EEC1 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
+		45F6B4B92A44E43E0090EEC1 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
+		45F6B4BA2A44E43E0090EEC1 /* GMSPinImageGlyph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPinImageGlyph.h; sourceTree = "<group>"; };
+		45F6B4BB2A44E43E0090EEC1 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
+		45F6B4BC2A44E43E0090EEC1 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
+		45F6B4BD2A44E43E0090EEC1 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
+		45F6B4BE2A44E43E0090EEC1 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
+		45F6B4BF2A44E43E0090EEC1 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
+		45F6B4C02A44E43E0090EEC1 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
+		45F6B4C12A44E43E0090EEC1 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
+		45F6B4C22A44E43E0090EEC1 /* GMSCollisionBehavior.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCollisionBehavior.h; sourceTree = "<group>"; };
+		45F6B4C32A44E43E0090EEC1 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
+		45F6B4C42A44E43E0090EEC1 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
+		45F6B4C52A44E43E0090EEC1 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		45F6B4C62A44E43E0090EEC1 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
 		8A53DD8A28F6D2BD00F4DF37 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -184,52 +241,6 @@
 		8A66418D253983AA000E9321 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		8A66418F253983B1000E9321 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		8A664196253983BC000E9321 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
-		8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
-		8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
-		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
-		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
-		8A7107E026526A8E00C2AD24 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
-		8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
-		8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
-		8A7107E526526A8E00C2AD24 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
-		8A7107E626526A8E00C2AD24 /* GMSMapID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapID.h; sourceTree = "<group>"; };
-		8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
-		8A7107E826526A8F00C2AD24 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
-		8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
-		8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
-		8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
-		8A7107EC26526A8F00C2AD24 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
-		8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
-		8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
-		8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
-		8A7107F026526A8F00C2AD24 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
-		8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
-		8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
-		8A7107F326526A8F00C2AD24 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
-		8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
-		8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
-		8A7107F626526A8F00C2AD24 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
-		8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
-		8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
-		8A7107FA26526A8F00C2AD24 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
-		8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
-		8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
-		8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
-		8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
-		8A71080026526A8F00C2AD24 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
-		8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
-		8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
-		8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
-		8A71080426526A8F00C2AD24 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
-		8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
-		8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
-		8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
-		8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
-		8A71080926526A9000C2AD24 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
-		8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
-		8A71080B26526A9000C2AD24 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
-		8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
-		8A71080D26526A9000C2AD24 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
 		8A71083F26526AE800C2AD24 /* GooglePlaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GooglePlaces.h; sourceTree = "<group>"; };
 		8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesDeprecationUtils.h; sourceTree = "<group>"; };
 		8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLocationOptions.h; sourceTree = "<group>"; };
@@ -265,7 +276,6 @@
 		8A8C8F1E25387A5800F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GooglePlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8F2F25387A7C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,53 +363,58 @@
 		8A08ACA7253998F10078DE66 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */,
-				8A7107EC26526A8F00C2AD24 /* GMSAddress.h */,
-				8A71080D26526A9000C2AD24 /* GMSCALayer.h */,
-				8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */,
-				8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */,
-				8A7107F326526A8F00C2AD24 /* GMSCircle.h */,
-				8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */,
-				8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */,
-				8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */,
-				8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */,
-				8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */,
-				8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */,
-				8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */,
-				8A7107E626526A8E00C2AD24 /* GMSMapID.h */,
-				8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */,
-				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
-				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
-				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
-				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
-				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
-				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
-				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
-				8A7107E026526A8E00C2AD24 /* GMSOverlay.h */,
-				8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */,
-				8A7107F626526A8F00C2AD24 /* GMSPanorama.h */,
-				8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */,
-				8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */,
-				8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */,
-				8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */,
-				8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */,
-				8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */,
-				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
-				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
-				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
-				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
-				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
-				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
-				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
-				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
-				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
-				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
-				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
-				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
-				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
+				45F6B4BC2A44E43E0090EEC1 /* GMSAccessibilityLabels.h */,
+				45F6B4C02A44E43E0090EEC1 /* GMSAddress.h */,
+				45F6B49A2A44E43D0090EEC1 /* GMSAdvancedMarker.h */,
+				45F6B49E2A44E43D0090EEC1 /* GMSCALayer.h */,
+				45F6B4B12A44E43D0090EEC1 /* GMSCameraPosition.h */,
+				45F6B4A72A44E43D0090EEC1 /* GMSCameraUpdate.h */,
+				45F6B4AA2A44E43D0090EEC1 /* GMSCircle.h */,
+				45F6B4C22A44E43E0090EEC1 /* GMSCollisionBehavior.h */,
+				45F6B4AD2A44E43D0090EEC1 /* GMSCoordinateBounds+GoogleMaps.h */,
+				45F6B4B62A44E43E0090EEC1 /* GMSGeocoder.h */,
+				45F6B4C12A44E43E0090EEC1 /* GMSGeometryUtils.h */,
+				45F6B4BE2A44E43E0090EEC1 /* GMSGroundOverlay.h */,
+				45F6B4A42A44E43D0090EEC1 /* GMSIndoorBuilding.h */,
+				45F6B4A12A44E43D0090EEC1 /* GMSIndoorDisplay.h */,
+				45F6B4AC2A44E43D0090EEC1 /* GMSIndoorLevel.h */,
+				45F6B4B32A44E43D0090EEC1 /* GMSMapID.h */,
+				45F6B4B72A44E43E0090EEC1 /* GMSMapLayer.h */,
+				45F6B4BF2A44E43E0090EEC1 /* GMSMapStyle.h */,
+				45F6B4982A44E43D0090EEC1 /* GMSMapView.h */,
+				45F6B4A82A44E43D0090EEC1 /* GMSMapView+Animation.h */,
+				45F6B4B42A44E43E0090EEC1 /* GMSMarker.h */,
+				45F6B4B22A44E43D0090EEC1 /* GMSMarkerAnimation.h */,
+				45F6B4942A44E43D0090EEC1 /* GMSMarkerLayer.h */,
+				45F6B49D2A44E43D0090EEC1 /* GMSMutablePath.h */,
+				45F6B4BD2A44E43E0090EEC1 /* GMSOrientation.h */,
+				45F6B4BB2A44E43E0090EEC1 /* GMSOverlay.h */,
+				45F6B4932A44E43D0090EEC1 /* GMSOverlayLayer.h */,
+				45F6B4B92A44E43E0090EEC1 /* GMSPanorama.h */,
+				45F6B4962A44E43D0090EEC1 /* GMSPanoramaCamera.h */,
+				45F6B4B02A44E43D0090EEC1 /* GMSPanoramaCameraUpdate.h */,
+				45F6B4B52A44E43E0090EEC1 /* GMSPanoramaLayer.h */,
+				45F6B4952A44E43D0090EEC1 /* GMSPanoramaLink.h */,
+				45F6B4A92A44E43D0090EEC1 /* GMSPanoramaService.h */,
+				45F6B4972A44E43D0090EEC1 /* GMSPanoramaSource.h */,
+				45F6B4A52A44E43D0090EEC1 /* GMSPanoramaView.h */,
+				45F6B4C42A44E43E0090EEC1 /* GMSPath.h */,
+				45F6B4A02A44E43D0090EEC1 /* GMSPinImage.h */,
+				45F6B4BA2A44E43E0090EEC1 /* GMSPinImageGlyph.h */,
+				45F6B49C2A44E43D0090EEC1 /* GMSPinImageOptions.h */,
+				45F6B49F2A44E43D0090EEC1 /* GMSPolygon.h */,
+				45F6B4AB2A44E43D0090EEC1 /* GMSPolygonLayer.h */,
+				45F6B4992A44E43D0090EEC1 /* GMSPolyline.h */,
+				45F6B49B2A44E43D0090EEC1 /* GMSProjection.h */,
+				45F6B4A62A44E43D0090EEC1 /* GMSServices.h */,
+				45F6B4C32A44E43E0090EEC1 /* GMSStampStyle.h */,
+				45F6B4A32A44E43D0090EEC1 /* GMSStrokeStyle.h */,
+				45F6B4AE2A44E43D0090EEC1 /* GMSStyleSpan.h */,
+				45F6B4A22A44E43D0090EEC1 /* GMSSyncTileLayer.h */,
+				45F6B4B82A44E43E0090EEC1 /* GMSTileLayer.h */,
+				45F6B4C62A44E43E0090EEC1 /* GMSUISettings.h */,
+				45F6B4AF2A44E43D0090EEC1 /* GMSURLTileLayer.h */,
+				45F6B4C52A44E43E0090EEC1 /* GoogleMaps.h */,
 			);
 			name = Headers;
 			path = "GoogleFrameworks/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Headers";
@@ -636,53 +651,58 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
-				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
-				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
-				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
-				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
-				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
-				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
-				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
-				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				8A71081726526A9000C2AD24 /* GMSMapID.h in Headers */,
-				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
-				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
-				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
-				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
-				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
-				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
-				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
-				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
-				8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */,
-				8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */,
-				8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */,
-				8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */,
-				8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */,
-				8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */,
-				8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */,
-				8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */,
-				8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */,
-				8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */,
-				8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */,
-				8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */,
-				8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */,
-				8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */,
-				8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */,
-				8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */,
-				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
-				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
-				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
-				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
-				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
-				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
-				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
-				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
-				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
-				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
-				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,
+				45F6B4D72A44E43E0090EEC1 /* GMSStrokeStyle.h in Headers */,
+				45F6B4DC2A44E43E0090EEC1 /* GMSMapView+Animation.h in Headers */,
+				45F6B4EC2A44E43E0090EEC1 /* GMSTileLayer.h in Headers */,
+				45F6B4D52A44E43E0090EEC1 /* GMSIndoorDisplay.h in Headers */,
+				45F6B4E32A44E43E0090EEC1 /* GMSURLTileLayer.h in Headers */,
+				45F6B4D42A44E43E0090EEC1 /* GMSPinImage.h in Headers */,
+				45F6B4D12A44E43E0090EEC1 /* GMSMutablePath.h in Headers */,
+				45F6B4F52A44E43E0090EEC1 /* GMSGeometryUtils.h in Headers */,
+				45F6B4EA2A44E43E0090EEC1 /* GMSGeocoder.h in Headers */,
+				45F6B4F92A44E43E0090EEC1 /* GoogleMaps.h in Headers */,
+				45F6B4CE2A44E43E0090EEC1 /* GMSAdvancedMarker.h in Headers */,
+				45F6B4CB2A44E43E0090EEC1 /* GMSPanoramaSource.h in Headers */,
+				45F6B4CA2A44E43E0090EEC1 /* GMSPanoramaCamera.h in Headers */,
+				45F6B4C92A44E43E0090EEC1 /* GMSPanoramaLink.h in Headers */,
+				45F6B4D62A44E43E0090EEC1 /* GMSSyncTileLayer.h in Headers */,
+				45F6B4EE2A44E43E0090EEC1 /* GMSPinImageGlyph.h in Headers */,
+				45F6B4F02A44E43E0090EEC1 /* GMSAccessibilityLabels.h in Headers */,
+				45F6B4D92A44E43E0090EEC1 /* GMSPanoramaView.h in Headers */,
+				45F6B4DA2A44E43E0090EEC1 /* GMSServices.h in Headers */,
+				45F6B4E72A44E43E0090EEC1 /* GMSMapID.h in Headers */,
+				45F6B4F82A44E43E0090EEC1 /* GMSPath.h in Headers */,
+				45F6B4DF2A44E43E0090EEC1 /* GMSPolygonLayer.h in Headers */,
+				45F6B4C82A44E43E0090EEC1 /* GMSMarkerLayer.h in Headers */,
+				45F6B4E22A44E43E0090EEC1 /* GMSStyleSpan.h in Headers */,
+				45F6B4F32A44E43E0090EEC1 /* GMSMapStyle.h in Headers */,
+				45F6B4CF2A44E43E0090EEC1 /* GMSProjection.h in Headers */,
+				45F6B4E42A44E43E0090EEC1 /* GMSPanoramaCameraUpdate.h in Headers */,
+				45F6B4DB2A44E43E0090EEC1 /* GMSCameraUpdate.h in Headers */,
+				45F6B4F22A44E43E0090EEC1 /* GMSGroundOverlay.h in Headers */,
+				45F6B4E62A44E43E0090EEC1 /* GMSMarkerAnimation.h in Headers */,
+				45F6B4CC2A44E43E0090EEC1 /* GMSMapView.h in Headers */,
+				45F6B4FA2A44E43E0090EEC1 /* GMSUISettings.h in Headers */,
+				45F6B4E12A44E43E0090EEC1 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
+				45F6B4ED2A44E43E0090EEC1 /* GMSPanorama.h in Headers */,
+				45F6B4D32A44E43E0090EEC1 /* GMSPolygon.h in Headers */,
+				45F6B4E92A44E43E0090EEC1 /* GMSPanoramaLayer.h in Headers */,
+				45F6B4EB2A44E43E0090EEC1 /* GMSMapLayer.h in Headers */,
+				45F6B4E52A44E43E0090EEC1 /* GMSCameraPosition.h in Headers */,
+				45F6B4D82A44E43E0090EEC1 /* GMSIndoorBuilding.h in Headers */,
+				45F6B4DE2A44E43E0090EEC1 /* GMSCircle.h in Headers */,
+				45F6B4E02A44E43E0090EEC1 /* GMSIndoorLevel.h in Headers */,
+				45F6B4F42A44E43E0090EEC1 /* GMSAddress.h in Headers */,
+				45F6B4E82A44E43E0090EEC1 /* GMSMarker.h in Headers */,
+				45F6B4F72A44E43E0090EEC1 /* GMSStampStyle.h in Headers */,
+				45F6B4C72A44E43E0090EEC1 /* GMSOverlayLayer.h in Headers */,
+				45F6B4CD2A44E43E0090EEC1 /* GMSPolyline.h in Headers */,
+				45F6B4D22A44E43E0090EEC1 /* GMSCALayer.h in Headers */,
+				45F6B4EF2A44E43E0090EEC1 /* GMSOverlay.h in Headers */,
+				45F6B4D02A44E43E0090EEC1 /* GMSPinImageOptions.h in Headers */,
+				45F6B4F12A44E43E0090EEC1 /* GMSOrientation.h in Headers */,
+				45F6B4DD2A44E43E0090EEC1 /* GMSPanoramaService.h in Headers */,
+				45F6B4F62A44E43E0090EEC1 /* GMSCollisionBehavior.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1029,7 +1049,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1085,7 +1105,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1108,7 +1128,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1139,7 +1159,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1170,7 +1190,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1199,7 +1219,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1228,7 +1248,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1257,7 +1277,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1286,7 +1306,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1315,7 +1335,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1344,7 +1364,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1373,7 +1393,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -7,6 +7,58 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		45F6B52F2A44E4950090EEC1 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4FB2A44E4930090EEC1 /* GMSIndoorDisplay.h */; };
+		45F6B5302A44E4950090EEC1 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4FC2A44E4930090EEC1 /* GMSStyleSpan.h */; };
+		45F6B5312A44E4950090EEC1 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4FD2A44E4930090EEC1 /* GMSCALayer.h */; };
+		45F6B5322A44E4950090EEC1 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4FE2A44E4930090EEC1 /* GMSMarker.h */; };
+		45F6B5332A44E4950090EEC1 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B4FF2A44E4930090EEC1 /* GMSPanoramaCamera.h */; };
+		45F6B5342A44E4950090EEC1 /* GMSPinImageGlyph.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5002A44E4940090EEC1 /* GMSPinImageGlyph.h */; };
+		45F6B5352A44E4950090EEC1 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5012A44E4940090EEC1 /* GMSStampStyle.h */; };
+		45F6B5362A44E4950090EEC1 /* GMSPinImageOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5022A44E4940090EEC1 /* GMSPinImageOptions.h */; };
+		45F6B5372A44E4950090EEC1 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5032A44E4940090EEC1 /* GMSGeocoder.h */; };
+		45F6B5382A44E4950090EEC1 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5042A44E4940090EEC1 /* GMSProjection.h */; };
+		45F6B5392A44E4950090EEC1 /* GMSAdvancedMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5052A44E4940090EEC1 /* GMSAdvancedMarker.h */; };
+		45F6B53A2A44E4950090EEC1 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5062A44E4940090EEC1 /* GMSOverlay.h */; };
+		45F6B53B2A44E4950090EEC1 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5072A44E4940090EEC1 /* GMSServices.h */; };
+		45F6B53C2A44E4950090EEC1 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5082A44E4940090EEC1 /* GMSGeometryUtils.h */; };
+		45F6B53D2A44E4950090EEC1 /* GMSMapID.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5092A44E4940090EEC1 /* GMSMapID.h */; };
+		45F6B53E2A44E4950090EEC1 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B50A2A44E4940090EEC1 /* GMSCircle.h */; };
+		45F6B53F2A44E4950090EEC1 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B50B2A44E4940090EEC1 /* GMSOrientation.h */; };
+		45F6B5402A44E4950090EEC1 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B50C2A44E4940090EEC1 /* GMSPath.h */; };
+		45F6B5412A44E4950090EEC1 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B50D2A44E4940090EEC1 /* GMSPanoramaLayer.h */; };
+		45F6B5422A44E4950090EEC1 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B50E2A44E4940090EEC1 /* GMSPanorama.h */; };
+		45F6B5432A44E4950090EEC1 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B50F2A44E4940090EEC1 /* GMSStrokeStyle.h */; };
+		45F6B5442A44E4950090EEC1 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5102A44E4940090EEC1 /* GMSCameraPosition.h */; };
+		45F6B5452A44E4950090EEC1 /* GMSCollisionBehavior.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5112A44E4940090EEC1 /* GMSCollisionBehavior.h */; };
+		45F6B5462A44E4950090EEC1 /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5122A44E4940090EEC1 /* GMSMarkerAnimation.h */; };
+		45F6B5472A44E4950090EEC1 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5132A44E4940090EEC1 /* GMSPanoramaService.h */; };
+		45F6B5482A44E4950090EEC1 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5142A44E4940090EEC1 /* GMSIndoorBuilding.h */; };
+		45F6B5492A44E4950090EEC1 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5152A44E4950090EEC1 /* GMSPolygon.h */; };
+		45F6B54A2A44E4950090EEC1 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5162A44E4950090EEC1 /* GMSMapStyle.h */; };
+		45F6B54B2A44E4950090EEC1 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5172A44E4950090EEC1 /* GMSAccessibilityLabels.h */; };
+		45F6B54C2A44E4950090EEC1 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5182A44E4950090EEC1 /* GMSTileLayer.h */; };
+		45F6B54D2A44E4950090EEC1 /* GMSPinImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5192A44E4950090EEC1 /* GMSPinImage.h */; };
+		45F6B54E2A44E4950090EEC1 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B51A2A44E4950090EEC1 /* GMSPolyline.h */; };
+		45F6B54F2A44E4950090EEC1 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B51B2A44E4950090EEC1 /* GMSPanoramaSource.h */; };
+		45F6B5502A44E4950090EEC1 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B51C2A44E4950090EEC1 /* GMSMutablePath.h */; };
+		45F6B5512A44E4950090EEC1 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B51D2A44E4950090EEC1 /* GMSMapView+Animation.h */; };
+		45F6B5522A44E4950090EEC1 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B51E2A44E4950090EEC1 /* GMSMarkerLayer.h */; };
+		45F6B5532A44E4950090EEC1 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B51F2A44E4950090EEC1 /* GMSURLTileLayer.h */; };
+		45F6B5542A44E4950090EEC1 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5202A44E4950090EEC1 /* GMSMapLayer.h */; };
+		45F6B5552A44E4950090EEC1 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5212A44E4950090EEC1 /* GMSOverlayLayer.h */; };
+		45F6B5562A44E4950090EEC1 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5222A44E4950090EEC1 /* GMSPanoramaView.h */; };
+		45F6B5572A44E4950090EEC1 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5232A44E4950090EEC1 /* GMSUISettings.h */; };
+		45F6B5582A44E4950090EEC1 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5242A44E4950090EEC1 /* GMSIndoorLevel.h */; };
+		45F6B5592A44E4950090EEC1 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5252A44E4950090EEC1 /* GMSCameraUpdate.h */; };
+		45F6B55A2A44E4950090EEC1 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5262A44E4950090EEC1 /* GMSPolygonLayer.h */; };
+		45F6B55B2A44E4950090EEC1 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5272A44E4950090EEC1 /* GMSPanoramaLink.h */; };
+		45F6B55C2A44E4950090EEC1 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5282A44E4950090EEC1 /* GMSSyncTileLayer.h */; };
+		45F6B55D2A44E4950090EEC1 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B5292A44E4950090EEC1 /* GoogleMaps.h */; };
+		45F6B55E2A44E4950090EEC1 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B52A2A44E4950090EEC1 /* GMSMapView.h */; };
+		45F6B55F2A44E4950090EEC1 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B52B2A44E4950090EEC1 /* GMSGroundOverlay.h */; };
+		45F6B5602A44E4950090EEC1 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B52C2A44E4950090EEC1 /* GMSCoordinateBounds+GoogleMaps.h */; };
+		45F6B5612A44E4950090EEC1 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B52D2A44E4950090EEC1 /* GMSPanoramaCameraUpdate.h */; };
+		45F6B5622A44E4950090EEC1 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 45F6B52E2A44E4950090EEC1 /* GMSAddress.h */; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
@@ -54,54 +106,8 @@
 		8A6642052539847A000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
 		8A66421625398491000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
 		8A66421725398499000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
-		8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
 		8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
-		8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E026526A8E00C2AD24 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E526526A8E00C2AD24 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081726526A9000C2AD24 /* GMSMapID.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E626526A8E00C2AD24 /* GMSMapID.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E826526A8F00C2AD24 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EC26526A8F00C2AD24 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082126526A9000C2AD24 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F026526A8F00C2AD24 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F326526A8F00C2AD24 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F626526A8F00C2AD24 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FA26526A8F00C2AD24 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080026526A8F00C2AD24 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080426526A8F00C2AD24 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080926526A9000C2AD24 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080B26526A9000C2AD24 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080D26526A9000C2AD24 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71083F26526AE800C2AD24 /* GooglePlaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -127,7 +133,6 @@
 		8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8B4E8E278317090014EB33 /* Metal.framework */; };
-		8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +153,58 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		45F6B4FB2A44E4930090EEC1 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
+		45F6B4FC2A44E4930090EEC1 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
+		45F6B4FD2A44E4930090EEC1 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
+		45F6B4FE2A44E4930090EEC1 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
+		45F6B4FF2A44E4930090EEC1 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
+		45F6B5002A44E4940090EEC1 /* GMSPinImageGlyph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPinImageGlyph.h; sourceTree = "<group>"; };
+		45F6B5012A44E4940090EEC1 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
+		45F6B5022A44E4940090EEC1 /* GMSPinImageOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPinImageOptions.h; sourceTree = "<group>"; };
+		45F6B5032A44E4940090EEC1 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
+		45F6B5042A44E4940090EEC1 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
+		45F6B5052A44E4940090EEC1 /* GMSAdvancedMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAdvancedMarker.h; sourceTree = "<group>"; };
+		45F6B5062A44E4940090EEC1 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
+		45F6B5072A44E4940090EEC1 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
+		45F6B5082A44E4940090EEC1 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
+		45F6B5092A44E4940090EEC1 /* GMSMapID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapID.h; sourceTree = "<group>"; };
+		45F6B50A2A44E4940090EEC1 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
+		45F6B50B2A44E4940090EEC1 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
+		45F6B50C2A44E4940090EEC1 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
+		45F6B50D2A44E4940090EEC1 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
+		45F6B50E2A44E4940090EEC1 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
+		45F6B50F2A44E4940090EEC1 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
+		45F6B5102A44E4940090EEC1 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
+		45F6B5112A44E4940090EEC1 /* GMSCollisionBehavior.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCollisionBehavior.h; sourceTree = "<group>"; };
+		45F6B5122A44E4940090EEC1 /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
+		45F6B5132A44E4940090EEC1 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
+		45F6B5142A44E4940090EEC1 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
+		45F6B5152A44E4950090EEC1 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
+		45F6B5162A44E4950090EEC1 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
+		45F6B5172A44E4950090EEC1 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
+		45F6B5182A44E4950090EEC1 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
+		45F6B5192A44E4950090EEC1 /* GMSPinImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPinImage.h; sourceTree = "<group>"; };
+		45F6B51A2A44E4950090EEC1 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
+		45F6B51B2A44E4950090EEC1 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
+		45F6B51C2A44E4950090EEC1 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
+		45F6B51D2A44E4950090EEC1 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
+		45F6B51E2A44E4950090EEC1 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
+		45F6B51F2A44E4950090EEC1 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
+		45F6B5202A44E4950090EEC1 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
+		45F6B5212A44E4950090EEC1 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
+		45F6B5222A44E4950090EEC1 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
+		45F6B5232A44E4950090EEC1 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
+		45F6B5242A44E4950090EEC1 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
+		45F6B5252A44E4950090EEC1 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
+		45F6B5262A44E4950090EEC1 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
+		45F6B5272A44E4950090EEC1 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
+		45F6B5282A44E4950090EEC1 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
+		45F6B5292A44E4950090EEC1 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		45F6B52A2A44E4950090EEC1 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
+		45F6B52B2A44E4950090EEC1 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
+		45F6B52C2A44E4950090EEC1 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
+		45F6B52D2A44E4950090EEC1 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
+		45F6B52E2A44E4950090EEC1 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
 		8A53DD8A28F6D2BD00F4DF37 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -184,52 +241,6 @@
 		8A66418D253983AA000E9321 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		8A66418F253983B1000E9321 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		8A664196253983BC000E9321 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
-		8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
-		8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
-		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
-		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
-		8A7107E026526A8E00C2AD24 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
-		8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
-		8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
-		8A7107E526526A8E00C2AD24 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
-		8A7107E626526A8E00C2AD24 /* GMSMapID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapID.h; sourceTree = "<group>"; };
-		8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
-		8A7107E826526A8F00C2AD24 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
-		8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
-		8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
-		8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
-		8A7107EC26526A8F00C2AD24 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
-		8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
-		8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
-		8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
-		8A7107F026526A8F00C2AD24 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
-		8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
-		8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
-		8A7107F326526A8F00C2AD24 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
-		8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
-		8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
-		8A7107F626526A8F00C2AD24 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
-		8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
-		8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
-		8A7107FA26526A8F00C2AD24 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
-		8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
-		8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
-		8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
-		8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
-		8A71080026526A8F00C2AD24 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
-		8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
-		8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
-		8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
-		8A71080426526A8F00C2AD24 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
-		8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
-		8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
-		8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
-		8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
-		8A71080926526A9000C2AD24 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
-		8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
-		8A71080B26526A9000C2AD24 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
-		8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
-		8A71080D26526A9000C2AD24 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
 		8A71083F26526AE800C2AD24 /* GooglePlaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GooglePlaces.h; sourceTree = "<group>"; };
 		8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesDeprecationUtils.h; sourceTree = "<group>"; };
 		8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLocationOptions.h; sourceTree = "<group>"; };
@@ -265,7 +276,6 @@
 		8A8C8F1E25387A5800F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GooglePlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8F2F25387A7C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,53 +363,58 @@
 		8A08ACA7253998F10078DE66 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */,
-				8A7107EC26526A8F00C2AD24 /* GMSAddress.h */,
-				8A71080D26526A9000C2AD24 /* GMSCALayer.h */,
-				8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */,
-				8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */,
-				8A7107F326526A8F00C2AD24 /* GMSCircle.h */,
-				8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */,
-				8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */,
-				8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */,
-				8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */,
-				8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */,
-				8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */,
-				8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */,
-				8A7107E626526A8E00C2AD24 /* GMSMapID.h */,
-				8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */,
-				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
-				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
-				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
-				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
-				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
-				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
-				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
-				8A7107E026526A8E00C2AD24 /* GMSOverlay.h */,
-				8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */,
-				8A7107F626526A8F00C2AD24 /* GMSPanorama.h */,
-				8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */,
-				8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */,
-				8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */,
-				8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */,
-				8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */,
-				8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */,
-				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
-				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
-				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
-				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
-				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
-				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
-				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
-				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
-				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
-				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
-				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
-				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
-				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
+				45F6B5172A44E4950090EEC1 /* GMSAccessibilityLabels.h */,
+				45F6B52E2A44E4950090EEC1 /* GMSAddress.h */,
+				45F6B5052A44E4940090EEC1 /* GMSAdvancedMarker.h */,
+				45F6B4FD2A44E4930090EEC1 /* GMSCALayer.h */,
+				45F6B5102A44E4940090EEC1 /* GMSCameraPosition.h */,
+				45F6B5252A44E4950090EEC1 /* GMSCameraUpdate.h */,
+				45F6B50A2A44E4940090EEC1 /* GMSCircle.h */,
+				45F6B5112A44E4940090EEC1 /* GMSCollisionBehavior.h */,
+				45F6B52C2A44E4950090EEC1 /* GMSCoordinateBounds+GoogleMaps.h */,
+				45F6B5032A44E4940090EEC1 /* GMSGeocoder.h */,
+				45F6B5082A44E4940090EEC1 /* GMSGeometryUtils.h */,
+				45F6B52B2A44E4950090EEC1 /* GMSGroundOverlay.h */,
+				45F6B5142A44E4940090EEC1 /* GMSIndoorBuilding.h */,
+				45F6B4FB2A44E4930090EEC1 /* GMSIndoorDisplay.h */,
+				45F6B5242A44E4950090EEC1 /* GMSIndoorLevel.h */,
+				45F6B5092A44E4940090EEC1 /* GMSMapID.h */,
+				45F6B5202A44E4950090EEC1 /* GMSMapLayer.h */,
+				45F6B5162A44E4950090EEC1 /* GMSMapStyle.h */,
+				45F6B52A2A44E4950090EEC1 /* GMSMapView.h */,
+				45F6B51D2A44E4950090EEC1 /* GMSMapView+Animation.h */,
+				45F6B4FE2A44E4930090EEC1 /* GMSMarker.h */,
+				45F6B5122A44E4940090EEC1 /* GMSMarkerAnimation.h */,
+				45F6B51E2A44E4950090EEC1 /* GMSMarkerLayer.h */,
+				45F6B51C2A44E4950090EEC1 /* GMSMutablePath.h */,
+				45F6B50B2A44E4940090EEC1 /* GMSOrientation.h */,
+				45F6B5062A44E4940090EEC1 /* GMSOverlay.h */,
+				45F6B5212A44E4950090EEC1 /* GMSOverlayLayer.h */,
+				45F6B50E2A44E4940090EEC1 /* GMSPanorama.h */,
+				45F6B4FF2A44E4930090EEC1 /* GMSPanoramaCamera.h */,
+				45F6B52D2A44E4950090EEC1 /* GMSPanoramaCameraUpdate.h */,
+				45F6B50D2A44E4940090EEC1 /* GMSPanoramaLayer.h */,
+				45F6B5272A44E4950090EEC1 /* GMSPanoramaLink.h */,
+				45F6B5132A44E4940090EEC1 /* GMSPanoramaService.h */,
+				45F6B51B2A44E4950090EEC1 /* GMSPanoramaSource.h */,
+				45F6B5222A44E4950090EEC1 /* GMSPanoramaView.h */,
+				45F6B50C2A44E4940090EEC1 /* GMSPath.h */,
+				45F6B5192A44E4950090EEC1 /* GMSPinImage.h */,
+				45F6B5002A44E4940090EEC1 /* GMSPinImageGlyph.h */,
+				45F6B5022A44E4940090EEC1 /* GMSPinImageOptions.h */,
+				45F6B5152A44E4950090EEC1 /* GMSPolygon.h */,
+				45F6B5262A44E4950090EEC1 /* GMSPolygonLayer.h */,
+				45F6B51A2A44E4950090EEC1 /* GMSPolyline.h */,
+				45F6B5042A44E4940090EEC1 /* GMSProjection.h */,
+				45F6B5072A44E4940090EEC1 /* GMSServices.h */,
+				45F6B5012A44E4940090EEC1 /* GMSStampStyle.h */,
+				45F6B50F2A44E4940090EEC1 /* GMSStrokeStyle.h */,
+				45F6B4FC2A44E4930090EEC1 /* GMSStyleSpan.h */,
+				45F6B5282A44E4950090EEC1 /* GMSSyncTileLayer.h */,
+				45F6B5182A44E4950090EEC1 /* GMSTileLayer.h */,
+				45F6B5232A44E4950090EEC1 /* GMSUISettings.h */,
+				45F6B51F2A44E4950090EEC1 /* GMSURLTileLayer.h */,
+				45F6B5292A44E4950090EEC1 /* GoogleMaps.h */,
 			);
 			name = Headers;
 			path = "GoogleFrameworks/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Headers";
@@ -636,53 +651,58 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
-				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
-				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
-				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
-				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
-				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
-				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
-				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
-				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				8A71081726526A9000C2AD24 /* GMSMapID.h in Headers */,
-				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
-				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
-				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
-				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
-				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
-				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
-				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
-				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
-				8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */,
-				8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */,
-				8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */,
-				8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */,
-				8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */,
-				8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */,
-				8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */,
-				8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */,
-				8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */,
-				8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */,
-				8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */,
-				8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */,
-				8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */,
-				8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */,
-				8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */,
-				8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */,
-				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
-				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
-				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
-				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
-				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
-				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
-				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
-				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
-				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
-				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
-				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,
+				45F6B5562A44E4950090EEC1 /* GMSPanoramaView.h in Headers */,
+				45F6B5302A44E4950090EEC1 /* GMSStyleSpan.h in Headers */,
+				45F6B5422A44E4950090EEC1 /* GMSPanorama.h in Headers */,
+				45F6B5592A44E4950090EEC1 /* GMSCameraUpdate.h in Headers */,
+				45F6B54D2A44E4950090EEC1 /* GMSPinImage.h in Headers */,
+				45F6B5512A44E4950090EEC1 /* GMSMapView+Animation.h in Headers */,
+				45F6B5452A44E4950090EEC1 /* GMSCollisionBehavior.h in Headers */,
+				45F6B5382A44E4950090EEC1 /* GMSProjection.h in Headers */,
+				45F6B5312A44E4950090EEC1 /* GMSCALayer.h in Headers */,
+				45F6B55C2A44E4950090EEC1 /* GMSSyncTileLayer.h in Headers */,
+				45F6B5492A44E4950090EEC1 /* GMSPolygon.h in Headers */,
+				45F6B53A2A44E4950090EEC1 /* GMSOverlay.h in Headers */,
+				45F6B54B2A44E4950090EEC1 /* GMSAccessibilityLabels.h in Headers */,
+				45F6B5392A44E4950090EEC1 /* GMSAdvancedMarker.h in Headers */,
+				45F6B5572A44E4950090EEC1 /* GMSUISettings.h in Headers */,
+				45F6B5482A44E4950090EEC1 /* GMSIndoorBuilding.h in Headers */,
+				45F6B5552A44E4950090EEC1 /* GMSOverlayLayer.h in Headers */,
+				45F6B5332A44E4950090EEC1 /* GMSPanoramaCamera.h in Headers */,
+				45F6B5322A44E4950090EEC1 /* GMSMarker.h in Headers */,
+				45F6B52F2A44E4950090EEC1 /* GMSIndoorDisplay.h in Headers */,
+				45F6B5432A44E4950090EEC1 /* GMSStrokeStyle.h in Headers */,
+				45F6B5532A44E4950090EEC1 /* GMSURLTileLayer.h in Headers */,
+				45F6B5602A44E4950090EEC1 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
+				45F6B5622A44E4950090EEC1 /* GMSAddress.h in Headers */,
+				45F6B54C2A44E4950090EEC1 /* GMSTileLayer.h in Headers */,
+				45F6B5462A44E4950090EEC1 /* GMSMarkerAnimation.h in Headers */,
+				45F6B5442A44E4950090EEC1 /* GMSCameraPosition.h in Headers */,
+				45F6B53C2A44E4950090EEC1 /* GMSGeometryUtils.h in Headers */,
+				45F6B5582A44E4950090EEC1 /* GMSIndoorLevel.h in Headers */,
+				45F6B5352A44E4950090EEC1 /* GMSStampStyle.h in Headers */,
+				45F6B54A2A44E4950090EEC1 /* GMSMapStyle.h in Headers */,
+				45F6B53E2A44E4950090EEC1 /* GMSCircle.h in Headers */,
+				45F6B54E2A44E4950090EEC1 /* GMSPolyline.h in Headers */,
+				45F6B53D2A44E4950090EEC1 /* GMSMapID.h in Headers */,
+				45F6B55A2A44E4950090EEC1 /* GMSPolygonLayer.h in Headers */,
+				45F6B53B2A44E4950090EEC1 /* GMSServices.h in Headers */,
+				45F6B55E2A44E4950090EEC1 /* GMSMapView.h in Headers */,
+				45F6B5372A44E4950090EEC1 /* GMSGeocoder.h in Headers */,
+				45F6B5472A44E4950090EEC1 /* GMSPanoramaService.h in Headers */,
+				45F6B5522A44E4950090EEC1 /* GMSMarkerLayer.h in Headers */,
+				45F6B5412A44E4950090EEC1 /* GMSPanoramaLayer.h in Headers */,
+				45F6B5502A44E4950090EEC1 /* GMSMutablePath.h in Headers */,
+				45F6B5612A44E4950090EEC1 /* GMSPanoramaCameraUpdate.h in Headers */,
+				45F6B5342A44E4950090EEC1 /* GMSPinImageGlyph.h in Headers */,
+				45F6B54F2A44E4950090EEC1 /* GMSPanoramaSource.h in Headers */,
+				45F6B5362A44E4950090EEC1 /* GMSPinImageOptions.h in Headers */,
+				45F6B53F2A44E4950090EEC1 /* GMSOrientation.h in Headers */,
+				45F6B55D2A44E4950090EEC1 /* GoogleMaps.h in Headers */,
+				45F6B55B2A44E4950090EEC1 /* GMSPanoramaLink.h in Headers */,
+				45F6B5402A44E4950090EEC1 /* GMSPath.h in Headers */,
+				45F6B55F2A44E4950090EEC1 /* GMSGroundOverlay.h in Headers */,
+				45F6B5542A44E4950090EEC1 /* GMSMapLayer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1029,7 +1049,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1085,7 +1105,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1108,7 +1128,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1139,7 +1159,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1170,7 +1190,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1199,7 +1219,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1228,7 +1248,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1257,7 +1277,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1286,7 +1306,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1315,7 +1335,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1344,7 +1364,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1373,7 +1393,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Package.swift
+++ b/Package.swift
@@ -41,28 +41,28 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/7.4.0/GoogleMaps.xcframework.zip",
-            checksum: "405f347ba7763b716e3228d081abfec930110f8528a4367b677c855ee6872b63"
+            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/8.0.0/GoogleMaps.xcframework.zip",
+            checksum: ""
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/7.4.0/GoogleMapsBase.xcframework.zip",
-            checksum: "627b75401c9b6a965dd2b28b203e8c11e45ef42adc71abf1f281e8b6a2dd33e0"
+            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/8.0.0/GoogleMapsBase.xcframework.zip",
+            checksum: ""
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/7.4.0/GoogleMapsCore.xcframework.zip",
-            checksum: "5e43192e2ef259ca29607e1c978d82e1575547b96c3947cdd7cecddf08f86405"
+            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/8.0.0/GoogleMapsCore.xcframework.zip",
+            checksum: ""
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/7.4.0/GoogleMapsM4B.xcframework.zip",
-            checksum: "7af88b77dbedbd545b5b71544159893ae714586051f0281b45cb4f1d2bb8f12c"
+            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/8.0.0/GoogleMapsM4B.xcframework.zip",
+            checksum: ""
         ),
         .binaryTarget(
             name: "GooglePlaces",
-            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/7.4.0/GooglePlaces.xcframework.zip",
-            checksum: "edbbccfb204eb2aa011137715c8bed06eba2e79c3fb7a5eadc108294373b3638"
+            url: "https://github.com/MateeDevs/GoogleMaps-SP/releases/download/8.0.0/GooglePlaces.xcframework.zip",
+            checksum: ""
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This project rebuilds Google's beta XCFrameworks so they can be added as a depen
 
 ## Requirements
 
-* [iOS 13.0](https://wikipedia.org/wiki/IOS_13) or later
+* [iOS 14.0](https://wikipedia.org/wiki/IOS_14) or later
 * [Xcode 14.0](https://developer.apple.com/xcode) or later
 
 ## Add as a dependecy to your Swift Package
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/MateeDevs/GoogleMaps-SP.git", .upToNextMinor(from: "7.4.0"))
+  .package(url: "https://github.com/MateeDevs/GoogleMaps-SP.git", .upToNextMinor(from: "8.0.0"))
 ]
 ```
 


### PR DESCRIPTION
# :pencil: Description
- This PR updates Google Maps frameworks to 8.0.0

# :bulb: What’s new?
- All frameworks updated to 8.0.0 (except GoogleMapsM4B - see below)

# :no_mouth: What’s missing?
- For some reason, GoogleMapsM4B is broken now, we have to investigate more

<img width="974" alt="Screenshot 2023-06-22 at 22 15 09" src="https://github.com/MateeDevs/GoogleMaps-SP/assets/3842139/23357416-f762-42fc-b62f-eafae4722ad0">

- Update checksums after GoogleMapsM4B issue is resolved

# :books: References
- https://developers.google.com/maps/documentation/ios-sdk/release-notes#May_17_2023